### PR TITLE
Fix: CodeDeploy configuration with S3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   AWS_REGION: ap-northeast-2
-  # S3_BUCKET_NAME: mavve-deploy-bucket
+  S3_BUCKET_NAME: aim-internie-app.kro.kr
   CODE_DEPLOY_APPLICATION_NAME: aim-codedeploy-app
   CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: aim-codedeploy-deployment-group
 
@@ -44,10 +44,22 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Create deployment package
+        run: |
+          mkdir -p deploy-package
+          cp -r build/libs deploy-package/
+          cp -r scripts deploy-package/
+          cp -r src/main/resources deploy-package/src/main/
+          cp appspec.yml deploy-package/
+          cd deploy-package && zip -r ../deploy-package.zip .
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp deploy-package.zip s3://$S3_BUCKET_NAME/deploy-package.zip
 
       - name: EC2에 배포
         run: >
           aws deploy create-deployment --application-name $CODE_DEPLOY_APPLICATION_NAME
           --deployment-config-name CodeDeployDefault.AllAtOnce
           --deployment-group-name $CODE_DEPLOY_DEPLOYMENT_GROUP_NAME
-          --github-location repository=$GITHUB_REPOSITORY,commitId=$GITHUB_SHA
+          --s3-location bucket=$S3_BUCKET_NAME,key=deploy-package.zip,bundleType=zip


### PR DESCRIPTION
## ✅ 요약
- Fix: CodeDeploy configuration with S3


## ⚠️ 어려웠던 점과 해결 과정
No such file or directory @ rb_sysopen - /opt/codedeploy-agent/deployment-root/2d8834ea-ba51-46f5-b400-08d53a132459/d-U00T5FE7E/deployment-archive/build/libs/ 
-> codedeploy에서 자꾸 에러가 발생함. 
-> GitHub에서 직접 CodeDeploy로 배포할 때 빌드된 파일들이 GitHub 리포지토리에 존재하지 않았음
-> GitHub Actions에서 ./gradlew bootJar 실행 → build/libs/aim-0.0.1-SNAPSHOT.jar 생성
-> 하지만 이 파일은 GitHub Actions 러너에만 존재, GitHub 리포지토리에는 커밋되지 않음
-> CodeDeploy가 GitHub에서 코드를 받아올 때 build/libs/ 디렉토리가 없음
-> appspec.yml에서 source: build/libs/를 찾으려 하지만 존재하지 않음

해결: S3를 중간 저장소로 사용해서 빌드 아티팩트를 전달
 
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
#12 
