### PR TITLE
Fix: directory creation in deployment package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
           mkdir -p deploy-package
           cp -r build/libs deploy-package/
           cp -r scripts deploy-package/
+          mkdir -p deploy-package/src/main/
           cp -r src/main/resources deploy-package/src/main/
           cp appspec.yml deploy-package/
           cd deploy-package && zip -r ../deploy-package.zip .


### PR DESCRIPTION
## ✅ 요약
Fix: directory creation in deployment package

## ⚠️ 어려웠던 점과 해결 과정
문제: deploy-package/src/main/ 디렉토리가 존재하지 않아서 resources 폴더를 복사 불가능 
해결: mkdir -p deploy-package/src/main/ 줄을 추가하여 필요한 디렉토리 구조를 먼저 생성하도록 수정 
  

## 📌 관련 이슈
#12 
