### PR TITLE
Fix: add RestTemplate Bean

### DIFF
--- a/src/main/java/com/aim/global/config/SecurityConfig.java
+++ b/src/main/java/com/aim/global/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @EnableWebSecurity
@@ -58,5 +59,11 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // RestTemplate Bean 추가
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }


### PR DESCRIPTION
## ✅ 요약
SecurityConfig파일에 RestTemplate Bean 등록 


## ⚠️ 어려웠던 점과 해결 과정
```
Description:

Parameter 5 of constructor in com.aim.auth.service.AuthService required a bean of type 'org.springframework.web.client.RestTemplate' that could not be found.

Action:

Consider defining a bean of type 'org.springframework.web.client.RestTemplate' in your configuration.
```
AuthService에서 RestTemplate을 의존성 주입받으려고 하는데, Spring Boot에서 RestTemplate Bean이 자동으로 생성되지 않음.
Spring Boot 3.x부터는 RestTemplate이 자동으로 Bean으로 등록되지 않는다.

해결: Configuration 클래스에 RestTemplate Bean 추가
 

## 📌 관련 이슈
#12 