### PR TITLE
Fix: add RestTemplate Timeout 설정

### DIFF
--- a/src/main/java/com/aim/global/config/SecurityConfig.java
+++ b/src/main/java/com/aim/global/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 
 @Configuration
 @EnableWebSecurity
@@ -70,7 +71,7 @@ public class SecurityConfig {
         // 타임아웃 설정
         HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
         factory.setConnectTimeout(5000);  // 연결 타임아웃: 5초
-        factory.setReadTimeout(5000);     // 읽기 타임아웃: 5초
+        factory.setReadTimeout(10000);    // 읽기 타임아웃: 10초
 
         restTemplate.setRequestFactory(factory);
         return restTemplate;

--- a/src/main/java/com/aim/global/config/SecurityConfig.java
+++ b/src/main/java/com/aim/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.aim.auth.service.jwt.UserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -64,6 +65,14 @@ public class SecurityConfig {
     // RestTemplate Bean 추가
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 타임아웃 설정
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);  // 연결 타임아웃: 5초
+        factory.setReadTimeout(5000);     // 읽기 타임아웃: 5초
+
+        restTemplate.setRequestFactory(factory);
+        return restTemplate;
     }
 }


### PR DESCRIPTION
## ✅ 요약
Fix: add RestTemplate Timeout 설정


## ⚠️ 어려웠던 점과 해결 과정
```
2025-09-18T18:52:13.281Z  WARN 7128 --- [aim] [l-1:housekeeper] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Thread starvation or clock leap detected (housekeeper delta=1m21s176ms811µs106ns).
```
 CPU가 과부하 상태!! 실제로 확인해보니 aws CPU가 100%였음. 또...........
그래서 확인해보니 restTemplate timeout 설정을 안해둠. 
timeout 설정을 안해두면 외부 API 호출이 무한정 대기 서버의 스레드가 고갈된다고 한다. 


## 📌 관련 이슈
#5 #12 